### PR TITLE
Update for rust 0.11

### DIFF
--- a/src/bignum/lib.rs
+++ b/src/bignum/lib.rs
@@ -1,10 +1,11 @@
-#[crate_id = "bignum#0.1.0-pre"];
+#[crate_id = "bignum#0.1.1-pre"];
 
 #[comment = "Bignum library for Rust"];
 #[crate_type = "rlib"];
 
 #[feature(macro_rules)];
 
+extern crate libc;
 extern crate gmp;
 extern crate num;
 extern crate rand;
@@ -13,7 +14,7 @@ use gmp::{Mpz, RandState};
 use std::fmt;
 use std::from_str::FromStr;
 use std::num::{One, Zero, ToStrRadix};
-use std::libc::c_ulong;
+use libc::c_ulong;
 use rand::Rng;
 use num::Integer;
 


### PR DESCRIPTION
`libc` is no longer in `std::libc` but in an external crate, so I changed that. Additionally, since fields in a struct are private by default, and since the compiler now flags unnecessary `priv`s as errors, I removed the `priv`s in `gmp.rs`.
