### PR TITLE
Fix owned string usage

### DIFF
--- a/deps/rust-gmp/gmp.rs
+++ b/deps/rust-gmp/gmp.rs
@@ -376,7 +376,7 @@ impl Div<Mpz, Mpz> for Mpz {
     fn div(&self, other: &Mpz) -> Mpz {
         unsafe {
             if other.is_zero() {
-                fail!("divide by zero".to_owned())
+                fail!("divide by zero")
             }
 
             let mut res = Mpz::new();
@@ -390,7 +390,7 @@ impl Rem<Mpz, Mpz> for Mpz {
     fn rem(&self, other: &Mpz) -> Mpz {
         unsafe {
             if other.is_zero() {
-                fail!("divide by zero".to_owned())
+                fail!("divide by zero")
             }
 
             let mut res = Mpz::new();
@@ -412,10 +412,10 @@ impl Neg<Mpz> for Mpz {
 
 impl ToPrimitive for Mpz {
     fn to_i64(&self) -> Option<i64> {
-        fail!("not implemented".to_owned())
+        fail!("not implemented")
     }
     fn to_u64(&self) -> Option<u64> {
-        fail!("not implemented".to_owned())
+        fail!("not implemented")
     }
 }
 
@@ -685,7 +685,7 @@ impl Mpq {
     pub fn invert(&self) -> Mpq {
         unsafe {
             if self.is_zero() {
-                fail!("divide by zero".to_owned())
+                fail!("divide by zero")
             }
 
             let mut res = Mpq::new();
@@ -761,7 +761,7 @@ impl Div<Mpq, Mpq> for Mpq {
     fn div(&self, other: &Mpq) -> Mpq {
         unsafe {
             if self.is_zero() {
-                fail!("divide by zero".to_owned())
+                fail!("divide by zero")
             }
 
             let mut res = Mpq::new();
@@ -783,10 +783,10 @@ impl Neg<Mpq> for Mpq {
 
 impl ToPrimitive for Mpq {
     fn to_i64(&self) -> Option<i64> {
-        fail!("not implemented".to_owned())
+        fail!("not implemented")
     }
     fn to_u64(&self) -> Option<u64> {
-        fail!("not implemented".to_owned())
+        fail!("not implemented")
     }
 }
 
@@ -960,7 +960,7 @@ impl Div<Mpf, Mpf> for Mpf {
     fn div(&self, other: &Mpf) -> Mpf {
         unsafe {
             if __gmpf_cmp_ui(&self.mpf, 0) == 0 {
-                fail!("divide by zero".to_owned())
+                fail!("divide by zero")
             }
 
             let mut res = Mpf::new(cmp::max(self.get_prec() as uint,
@@ -1107,13 +1107,13 @@ mod test_mpz {
     #[test]
     fn test_to_str_radix() {
         let x: Mpz = FromPrimitive::from_int(255).unwrap();
-        assert!(x.to_str_radix(16) == "ff".to_owned());
+        assert!(x.to_str_radix(16).as_slice() == "ff");
     }
 
     #[test]
     fn test_to_str() {
         let x: Mpz = FromStr::from_str("1234567890").unwrap();
-        assert!(x.to_str() == "1234567890".to_owned());
+        assert!(x.to_str().as_slice() == "1234567890");
     }
 
     #[test]
@@ -1134,7 +1134,7 @@ mod test_mpz {
     #[test]
     fn test_from_int() {
         let x: Mpz = FromPrimitive::from_int(150).unwrap();
-        assert!(x.to_str() == "150".to_owned());
+        assert!(x.to_str().as_slice() == "150");
         assert!(x == FromStr::from_str("150").unwrap());
     }
 

--- a/deps/rust-gmp/gmp.rs
+++ b/deps/rust-gmp/gmp.rs
@@ -376,7 +376,7 @@ impl Div<Mpz, Mpz> for Mpz {
     fn div(&self, other: &Mpz) -> Mpz {
         unsafe {
             if other.is_zero() {
-                fail!(~"divide by zero")
+                fail!("divide by zero".to_owned())
             }
 
             let mut res = Mpz::new();
@@ -390,7 +390,7 @@ impl Rem<Mpz, Mpz> for Mpz {
     fn rem(&self, other: &Mpz) -> Mpz {
         unsafe {
             if other.is_zero() {
-                fail!(~"divide by zero")
+                fail!("divide by zero".to_owned())
             }
 
             let mut res = Mpz::new();
@@ -412,10 +412,10 @@ impl Neg<Mpz> for Mpz {
 
 impl ToPrimitive for Mpz {
     fn to_i64(&self) -> Option<i64> {
-        fail!(~"not implemented")
+        fail!("not implemented".to_owned())
     }
     fn to_u64(&self) -> Option<u64> {
-        fail!(~"not implemented")
+        fail!("not implemented".to_owned())
     }
 }
 
@@ -685,7 +685,7 @@ impl Mpq {
     pub fn invert(&self) -> Mpq {
         unsafe {
             if self.is_zero() {
-                fail!(~"divide by zero")
+                fail!("divide by zero".to_owned())
             }
 
             let mut res = Mpq::new();
@@ -761,7 +761,7 @@ impl Div<Mpq, Mpq> for Mpq {
     fn div(&self, other: &Mpq) -> Mpq {
         unsafe {
             if self.is_zero() {
-                fail!(~"divide by zero")
+                fail!("divide by zero".to_owned())
             }
 
             let mut res = Mpq::new();
@@ -783,10 +783,10 @@ impl Neg<Mpq> for Mpq {
 
 impl ToPrimitive for Mpq {
     fn to_i64(&self) -> Option<i64> {
-        fail!(~"not implemented")
+        fail!("not implemented".to_owned())
     }
     fn to_u64(&self) -> Option<u64> {
-        fail!(~"not implemented")
+        fail!("not implemented".to_owned())
     }
 }
 
@@ -960,7 +960,7 @@ impl Div<Mpf, Mpf> for Mpf {
     fn div(&self, other: &Mpf) -> Mpf {
         unsafe {
             if __gmpf_cmp_ui(&self.mpf, 0) == 0 {
-                fail!(~"divide by zero")
+                fail!("divide by zero".to_owned())
             }
 
             let mut res = Mpf::new(cmp::max(self.get_prec() as uint,
@@ -1107,13 +1107,13 @@ mod test_mpz {
     #[test]
     fn test_to_str_radix() {
         let x: Mpz = FromPrimitive::from_int(255).unwrap();
-        assert!(x.to_str_radix(16) == ~"ff");
+        assert!(x.to_str_radix(16) == "ff".to_owned());
     }
 
     #[test]
     fn test_to_str() {
         let x: Mpz = FromStr::from_str("1234567890").unwrap();
-        assert!(x.to_str() == ~"1234567890");
+        assert!(x.to_str() == "1234567890".to_owned());
     }
 
     #[test]
@@ -1134,7 +1134,7 @@ mod test_mpz {
     #[test]
     fn test_from_int() {
         let x: Mpz = FromPrimitive::from_int(150).unwrap();
-        assert!(x.to_str() == ~"150");
+        assert!(x.to_str() == "150".to_owned());
         assert!(x == FromStr::from_str("150").unwrap());
     }
 

--- a/src/bignum/lib.rs
+++ b/src/bignum/lib.rs
@@ -365,25 +365,25 @@ mod test_biguint {
     #[test]
     fn test_from_primitive() {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
-        assert_eq!(two.to_str(), "2".to_owned());
+        assert_eq!(two.to_str().as_slice(), "2");
     }
 
     #[test]
     fn test_from_str() {
         let two: BigUint = FromStr::from_str("2").unwrap();
-        assert_eq!(two.to_str(), "2".to_owned());
+        assert_eq!(two.to_str().as_slice(), "2");
     }
 
     #[test]
     fn test_from_str_radix() {
         let two = BigUint::from_str_radix("1a", 16).unwrap();
-        assert_eq!(two.to_str(), "26".to_owned());
+        assert_eq!(two.to_str().as_slice(), "26");
     }
 
     #[test]
     fn test_to_biguint() {
         let three = 3u.to_biguint().unwrap();
-        assert_eq!(three.to_str(), "3".to_owned());
+        assert_eq!(three.to_str().as_slice(), "3");
     }
 
     #[test]
@@ -411,8 +411,8 @@ mod test_biguint {
     fn test_zero_and_one() {
         let zero: BigUint = Zero::zero();
         let one: BigUint = One::one();
-        assert_eq!(zero.to_str(), "0".to_owned());
-        assert_eq!(one.to_str(), "1".to_owned());
+        assert_eq!(zero.to_str().as_slice(), "0");
+        assert_eq!(one.to_str().as_slice(), "1");
     }
 
     #[test]
@@ -436,8 +436,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.add(&three).to_str(), "5".to_owned());
-        assert_eq!((two + three).to_str(), "5".to_owned());
+        assert_eq!(two.add(&three).to_str().as_slice(), "5");
+        assert_eq!((two + three).to_str().as_slice(), "5");
     }
 
     #[test]
@@ -445,8 +445,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(three.sub(&two).to_str(), "1".to_owned());
-        assert_eq!((three - two).to_str(), "1".to_owned());
+        assert_eq!(three.sub(&two).to_str().as_slice(), "1");
+        assert_eq!((three - two).to_str().as_slice(), "1");
     }
 
     #[test]
@@ -454,8 +454,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.mul(&three).to_str(), "6".to_owned());
-        assert_eq!((two * three).to_str(), "6".to_owned());
+        assert_eq!(two.mul(&three).to_str().as_slice(), "6");
+        assert_eq!((two * three).to_str().as_slice(), "6");
     }
 
     #[test]
@@ -569,15 +569,15 @@ mod test_bigint {
     fn test_zero_and_one() {
         let zero: BigInt = Zero::zero();
         let one: BigInt = One::one();
-        assert_eq!(zero.to_str(), "0".to_owned());
-        assert_eq!(one.to_str(), "1".to_owned());
+        assert_eq!(zero.to_str().as_slice(), "0");
+        assert_eq!(one.to_str().as_slice(), "1");
     }
 
     #[test]
     fn test_to_biguint() {
         let three: BigInt = FromPrimitive::from_int(3).unwrap();
         let minusthree: BigInt = FromPrimitive::from_int(-3).unwrap();
-        assert_eq!(three.to_biguint().unwrap().to_str(), "3".to_owned());
+        assert_eq!(three.to_biguint().unwrap().to_str().as_slice(), "3");
         assert_eq!(minusthree.to_biguint(), None);
     }
 
@@ -586,8 +586,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.add(&three).to_str(), "5".to_owned());
-        assert_eq!((two + three).to_str(), "5".to_owned());
+        assert_eq!(two.add(&three).to_str().as_slice(), "5");
+        assert_eq!((two + three).to_str().as_slice(), "5");
     }
 
     #[test]
@@ -595,8 +595,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(three.sub(&two).to_str(), "1".to_owned());
-        assert_eq!((three - two).to_str(), "1".to_owned());
+        assert_eq!(three.sub(&two).to_str().as_slice(), "1");
+        assert_eq!((three - two).to_str().as_slice(), "1");
     }
 
     #[test]
@@ -604,8 +604,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.mul(&three).to_str(), "6".to_owned());
-        assert_eq!((two * three).to_str(), "6".to_owned());
+        assert_eq!(two.mul(&three).to_str().as_slice(), "6");
+        assert_eq!((two * three).to_str().as_slice(), "6");
     }
 
     #[test]

--- a/src/bignum/lib.rs
+++ b/src/bignum/lib.rs
@@ -365,25 +365,25 @@ mod test_biguint {
     #[test]
     fn test_from_primitive() {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
-        assert_eq!(two.to_str(), ~"2");
+        assert_eq!(two.to_str(), "2".to_owned());
     }
 
     #[test]
     fn test_from_str() {
         let two: BigUint = FromStr::from_str("2").unwrap();
-        assert_eq!(two.to_str(), ~"2");
+        assert_eq!(two.to_str(), "2".to_owned());
     }
 
     #[test]
     fn test_from_str_radix() {
         let two = BigUint::from_str_radix("1a", 16).unwrap();
-        assert_eq!(two.to_str(), ~"26");
+        assert_eq!(two.to_str(), "26".to_owned());
     }
 
     #[test]
     fn test_to_biguint() {
         let three = 3u.to_biguint().unwrap();
-        assert_eq!(three.to_str(), ~"3");
+        assert_eq!(three.to_str(), "3".to_owned());
     }
 
     #[test]
@@ -411,8 +411,8 @@ mod test_biguint {
     fn test_zero_and_one() {
         let zero: BigUint = Zero::zero();
         let one: BigUint = One::one();
-        assert_eq!(zero.to_str(), ~"0");
-        assert_eq!(one.to_str(), ~"1");
+        assert_eq!(zero.to_str(), "0".to_owned());
+        assert_eq!(one.to_str(), "1".to_owned());
     }
 
     #[test]
@@ -436,8 +436,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.add(&three).to_str(), ~"5");
-        assert_eq!((two + three).to_str(), ~"5");
+        assert_eq!(two.add(&three).to_str(), "5".to_owned());
+        assert_eq!((two + three).to_str(), "5".to_owned());
     }
 
     #[test]
@@ -445,8 +445,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(three.sub(&two).to_str(), ~"1");
-        assert_eq!((three - two).to_str(), ~"1");
+        assert_eq!(three.sub(&two).to_str(), "1".to_owned());
+        assert_eq!((three - two).to_str(), "1".to_owned());
     }
 
     #[test]
@@ -454,8 +454,8 @@ mod test_biguint {
         let two: BigUint = FromPrimitive::from_uint(2).unwrap();
         let three: BigUint = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.mul(&three).to_str(), ~"6");
-        assert_eq!((two * three).to_str(), ~"6");
+        assert_eq!(two.mul(&three).to_str(), "6".to_owned());
+        assert_eq!((two * three).to_str(), "6".to_owned());
     }
 
     #[test]
@@ -569,15 +569,15 @@ mod test_bigint {
     fn test_zero_and_one() {
         let zero: BigInt = Zero::zero();
         let one: BigInt = One::one();
-        assert_eq!(zero.to_str(), ~"0");
-        assert_eq!(one.to_str(), ~"1");
+        assert_eq!(zero.to_str(), "0".to_owned());
+        assert_eq!(one.to_str(), "1".to_owned());
     }
 
     #[test]
     fn test_to_biguint() {
         let three: BigInt = FromPrimitive::from_int(3).unwrap();
         let minusthree: BigInt = FromPrimitive::from_int(-3).unwrap();
-        assert_eq!(three.to_biguint().unwrap().to_str(), ~"3");
+        assert_eq!(three.to_biguint().unwrap().to_str(), "3".to_owned());
         assert_eq!(minusthree.to_biguint(), None);
     }
 
@@ -586,8 +586,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.add(&three).to_str(), ~"5");
-        assert_eq!((two + three).to_str(), ~"5");
+        assert_eq!(two.add(&three).to_str(), "5".to_owned());
+        assert_eq!((two + three).to_str(), "5".to_owned());
     }
 
     #[test]
@@ -595,8 +595,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(three.sub(&two).to_str(), ~"1");
-        assert_eq!((three - two).to_str(), ~"1");
+        assert_eq!(three.sub(&two).to_str(), "1".to_owned());
+        assert_eq!((three - two).to_str(), "1".to_owned());
     }
 
     #[test]
@@ -604,8 +604,8 @@ mod test_bigint {
         let two: BigInt = FromPrimitive::from_uint(2).unwrap();
         let three: BigInt = FromPrimitive::from_uint(3).unwrap();
 
-        assert_eq!(two.mul(&three).to_str(), ~"6");
-        assert_eq!((two * three).to_str(), ~"6");
+        assert_eq!(two.mul(&three).to_str(), "6".to_owned());
+        assert_eq!((two * three).to_str(), "6".to_owned());
     }
 
     #[test]


### PR DESCRIPTION
Hi!

Recently [`~"string"` literals have been removed](https://github.com/mozilla/rust/pull/13877) from rust master, being replaced by `"string".to_owned()`.

The first commit is just an automatic conversion from the first form to the later, and by itself already makes the library compilable again on rust-nighly.

The second one removes multiple uses of `"string".to_owned()` that were unnecessary: `"string"` evaluates to `&'static str`, which is enough most of the time, and doesn't need heap allocation. It probably won't make any significant difference on speed or memory usage, but avoiding heap allocation when possible seems to be the current best practice for idiomatic rust.
